### PR TITLE
Feature(sitemap): named files chunking strategy

### DIFF
--- a/.changeset/floppy-times-grab.md
+++ b/.changeset/floppy-times-grab.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/sitemap': major
+---
+
+Adds the ability to split sitemap generation into chunks based oncustomizable logic. This allows for better management of largesitemaps and improved performance.The new `chunks` option in the sitemap configuration allows users todefine functions that categorize sitemap items into different chunks.Each chunk is then written to a separate sitemap file.This change introduces a new `writeSitemapChunk` function to handlethe writing of individual sitemap chunks.

--- a/packages/integrations/sitemap/src/schema.ts
+++ b/packages/integrations/sitemap/src/schema.ts
@@ -47,6 +47,7 @@ export const SitemapOptionsSchema = z
 			})
 			.optional()
 			.default(SITEMAP_CONFIG_DEFAULTS.namespaces),
-	})
+		chunks: z.record(z.function().args(z.any()).returns(z.any())).optional(),
+		})
 	.strict()
 	.default(SITEMAP_CONFIG_DEFAULTS);

--- a/packages/integrations/sitemap/src/write-sitemap-chunk.ts
+++ b/packages/integrations/sitemap/src/write-sitemap-chunk.ts
@@ -1,0 +1,127 @@
+import { createWriteStream, type WriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { normalize, resolve } from 'node:path';
+import { pipeline, Readable } from 'node:stream';
+import { promisify } from 'node:util';
+import type { AstroConfig } from 'astro';
+import { SitemapAndIndexStream, SitemapIndexStream, SitemapStream } from 'sitemap';
+import replace from 'stream-replace-string';
+import type { SitemapItem } from './index.js';
+
+type WriteSitemapChunkConfig = {
+	filenameBase: string;
+	hostname: string;
+	sitemapHostname?: string;
+	sourceData: Record<string, SitemapItem[]>;
+	destinationDir: string;
+	customSitemaps?: string[];
+	publicBasePath?: string;
+	limit?: number;
+	xslURL?: string;
+	lastmod?: string;
+	namespaces?: {
+		news?: boolean;
+		xhtml?: boolean;
+		image?: boolean;
+		video?: boolean;
+	};
+};
+
+// adapted from sitemap.js/sitemap-simple
+export async function writeSitemapChunk(
+	{
+		filenameBase,
+		hostname,
+		sitemapHostname = hostname,
+		sourceData,
+		destinationDir,
+		limit = 50000,
+		customSitemaps = [],
+		publicBasePath = './',
+		xslURL: xslUrl,
+		lastmod,
+		namespaces = { news: true, xhtml: true, image: true, video: true },
+	}: WriteSitemapChunkConfig,
+	astroConfig: AstroConfig,
+) {
+	await mkdir(destinationDir, { recursive: true });
+	
+	// Normalize publicBasePath
+	let normalizedPublicBasePath = publicBasePath;
+	if (!normalizedPublicBasePath.endsWith('/')) {
+		normalizedPublicBasePath += '/';
+	}
+
+	// Array to collect all sitemap URLs for the index
+	const sitemapUrls: Array<{ url: string; lastmod?: string }> = [];
+
+	// Process each chunk separately
+	for (const [chunkName, items] of Object.entries(sourceData)) {
+		const sitemapAndIndexStream = new SitemapAndIndexStream({
+			limit,
+			xslUrl,
+			getSitemapStream: (i) => {
+				const sitemapStream = new SitemapStream({
+					hostname,
+					xslUrl,
+					// Custom namespace handling
+					xmlns: {
+						news: namespaces?.news !== false,
+						xhtml: namespaces?.xhtml !== false,
+						image: namespaces?.image !== false,
+						video: namespaces?.video !== false,
+					},
+				});
+				
+				const path = `./${filenameBase}-${chunkName}-${i}.xml`;
+				const writePath = resolve(destinationDir, path);
+				const publicPath = normalize(normalizedPublicBasePath + path);
+
+				let stream: WriteStream;
+				if (astroConfig.trailingSlash === 'never' || astroConfig.build.format === 'file') {
+					// workaround for trailing slash issue in sitemap.js
+					const host = hostname.endsWith('/') ? hostname.slice(0, -1) : hostname;
+					const searchStr = `<loc>${host}/</loc>`;
+					const replaceStr = `<loc>${host}</loc>`;
+					stream = sitemapStream
+						.pipe(replace(searchStr, replaceStr))
+						.pipe(createWriteStream(writePath));
+				} else {
+					stream = sitemapStream.pipe(createWriteStream(writePath));
+				}
+
+				const url = new URL(publicPath, sitemapHostname).toString();
+				
+				// Collect this sitemap URL for the index
+				sitemapUrls.push({ url, lastmod });
+				
+				return [{ url, lastmod }, sitemapStream, stream];
+			},
+		});
+
+		// Create a readable stream from this chunk's items
+		const dataStream = Readable.from(items);
+
+		// Write this chunk's sitemap(s)
+		await promisify(pipeline)(dataStream, sitemapAndIndexStream);
+	}
+
+	// Now create the sitemap index with all the generated sitemaps
+	const indexStream = new SitemapIndexStream({ xslUrl });
+	const indexPath = resolve(destinationDir, `./${filenameBase}-index.xml`);
+	const indexWriteStream = createWriteStream(indexPath);
+
+	// Add custom sitemaps to the index
+	for (const url of customSitemaps) {
+		indexStream.write({ url, lastmod });
+	}
+
+	// Add all generated sitemaps to the index
+	for (const sitemapUrl of sitemapUrls) {
+		indexStream.write(sitemapUrl);
+	}
+
+	indexStream.end();
+
+	return await promisify(pipeline)(indexStream, indexWriteStream);
+}

--- a/packages/integrations/sitemap/src/write-sitemap.ts
+++ b/packages/integrations/sitemap/src/write-sitemap.ts
@@ -93,7 +93,7 @@ export async function writeSitemap(
 			sitemapAndIndexStream,
 			{ url, lastmod },
 			'utf8',
-			() => {},
+			() => { },
 		);
 	}
 	return promisify(pipeline)(src, sitemapAndIndexStream, createWriteStream(indexPath));

--- a/packages/integrations/sitemap/test/chunks-files.test.js
+++ b/packages/integrations/sitemap/test/chunks-files.test.js
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { sitemap } from './fixtures/static/deps.mjs';
+import { loadFixture, readXML } from './test-utils.js';
+
+describe('Sitemap with chunked files', () => {
+	/** @type {import('./test-utils.js').Fixture} */
+	let fixture;
+	/** @type {string[]} */
+	let blogUrls;
+	let glossaryUrls;
+	let pagesUrls;
+
+	before(async () => {
+		fixture = await loadFixture({
+			root: './fixtures/chunks/',
+			integrations: [
+				sitemap({
+					serialize(item) {
+						return item
+					},
+					chunks: {
+						'blog': (item) => {
+							if (/blog/.test(item.url)) {
+								item.changefreq = 'weekly';
+								item.lastmod = new Date();
+								item.priority = 0.9;
+								return item;
+							}
+						},
+						'glossary': (item) => {
+							if (/glossary/.test(item.url)) {
+								item.changefreq = 'weekly';
+								item.lastmod = new Date();
+								item.priority = 0.9;
+								return item;
+							}
+						}
+					},
+				}),
+			],
+		});
+		await fixture.build();
+		const [blogUrlsRaw, glossaryUrlsRaw, pagesUrlsRaw] = await Promise.all([
+			readXML(fixture.readFile('/sitemap-blog-0.xml')),
+			readXML(fixture.readFile('/sitemap-glossary-0.xml')),
+			readXML(fixture.readFile('/sitemap-pages-0.xml')),
+		]);
+		const flatMapUrls = (data) => data.urlset.url.map((url) => url.loc[0])
+		blogUrls = flatMapUrls(blogUrlsRaw);
+		glossaryUrls = flatMapUrls(glossaryUrlsRaw)
+		pagesUrls = flatMapUrls(pagesUrlsRaw)
+	});
+
+	it('includes defined custom pages', async () => {
+		assert.equal(blogUrls.includes('http://example.com/blog/one/'), true);
+		assert.equal(blogUrls.includes('http://example.com/blog/two/'), true);
+		assert.equal(glossaryUrls.includes('http://example.com/glossary/one/'), true);
+		assert.equal(glossaryUrls.includes('http://example.com/glossary/two/'), true);
+		assert.equal(pagesUrls.includes('http://example.com/one/'), true);
+		assert.equal(pagesUrls.includes('http://example.com/two/'), true);
+	});
+});

--- a/packages/integrations/sitemap/test/fixtures/chunks/astro.config.mjs
+++ b/packages/integrations/sitemap/test/fixtures/chunks/astro.config.mjs
@@ -1,0 +1,23 @@
+import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	integrations: [
+		sitemap({
+			chunks: {
+				'blog': (item) => {
+					if (/blog/.test(item.url)) {
+						item.changefreq = 'weekly';
+						item.lastmod = new Date();
+						item.priority = 0.9;
+						return item;
+					}
+				}
+			},
+		}),
+	],
+	site: 'http://example.com',
+	redirects: {
+		'/redirect': '/'
+	},
+})

--- a/packages/integrations/sitemap/test/fixtures/chunks/deps.mjs
+++ b/packages/integrations/sitemap/test/fixtures/chunks/deps.mjs
@@ -1,0 +1,1 @@
+export { default as sitemap } from '@astrojs/sitemap';

--- a/packages/integrations/sitemap/test/fixtures/chunks/package.json
+++ b/packages/integrations/sitemap/test/fixtures/chunks/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/sitemap-chunks",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "astro": "workspace:*",
+    "@astrojs/sitemap": "workspace:*"
+  }
+}

--- a/packages/integrations/sitemap/test/fixtures/chunks/src/pages/123.astro
+++ b/packages/integrations/sitemap/test/fixtures/chunks/src/pages/123.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>123</title>
+	</head>
+	<body>
+		<h1>123</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/fixtures/chunks/src/pages/404.astro
+++ b/packages/integrations/sitemap/test/fixtures/chunks/src/pages/404.astro
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<title>404</title>
+	</head>
+	<body>
+		<h1>404</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/fixtures/chunks/src/pages/[slug].astro
+++ b/packages/integrations/sitemap/test/fixtures/chunks/src/pages/[slug].astro
@@ -1,0 +1,17 @@
+---
+export function getStaticPaths() {
+  return [
+    { params: { slug: 'one' }, props: { title: 'One' } },
+    { params: { slug: 'two' }, props: { title: 'Two' } },
+  ]
+}
+---
+
+<html>
+	<head>
+		<title>{Astro.props.title}</title>
+	</head>
+	<body>
+		<h1>{Astro.props.title}</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/fixtures/chunks/src/pages/blog/[slug].astro
+++ b/packages/integrations/sitemap/test/fixtures/chunks/src/pages/blog/[slug].astro
@@ -1,0 +1,17 @@
+---
+export function getStaticPaths() {
+  return [
+    { params: { slug: 'one' }, props: { title: 'One' } },
+    { params: { slug: 'two' }, props: { title: 'Two' } },
+  ]
+}
+---
+
+<html>
+	<head>
+		<title>{Astro.props.title}</title>
+	</head>
+	<body>
+		<h1>{Astro.props.title}</h1>
+	</body>
+</html>

--- a/packages/integrations/sitemap/test/fixtures/chunks/src/pages/endpoint.json.ts
+++ b/packages/integrations/sitemap/test/fixtures/chunks/src/pages/endpoint.json.ts
@@ -1,0 +1,6 @@
+export async function GET({}) {
+	return Response.json({
+		name: 'Astro',
+		url: 'https://astro.build/',
+	});
+}

--- a/packages/integrations/sitemap/test/fixtures/chunks/src/pages/glossary/[slug].astro
+++ b/packages/integrations/sitemap/test/fixtures/chunks/src/pages/glossary/[slug].astro
@@ -1,0 +1,17 @@
+---
+export function getStaticPaths() {
+  return [
+    { params: { slug: 'one' }, props: { title: 'One' } },
+    { params: { slug: 'two' }, props: { title: 'Two' } },
+  ]
+}
+---
+
+<html>
+	<head>
+		<title>{Astro.props.title}</title>
+	</head>
+	<body>
+		<h1>{Astro.props.title}</h1>
+	</body>
+</html>


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!


- Before/after screenshots can help as well.
- Don't forget a changeset! Run `pnpm changeset`.
- See https://contribute.docs.astro.build/docs-for-code-changes/changesets/ for more info on writing changesets.

## New sitemap optional configuration for named sitemap files chunking strategy

Adds a chunks option to the sitemap configuration schema.
This allows users to define custom chunking strategies for
generating sitemaps, providing flexibility in how the sitemap
is split into multiple files.

````js

			integrations: [
				sitemap({
					serialize(item) {
						return item
					},
					chunks: {
						'blog': (item) => {
							if (/blog/.test(item.url)) {
								item.changefreq = 'weekly';
								item.lastmod = new Date();
								item.priority = 0.9;
								return item;
							}
						},
						'glossary': (item) => {
							if (/glossary/.test(item.url)) {
								item.changefreq = 'weekly';
								item.lastmod = new Date();
								item.priority = 0.9;
								return item;
							}
						}
					},
				}),
			],
````
## Testing

<!-- How was this change tested? -->
<img width="517" height="310" alt="image" src="https://github.com/user-attachments/assets/a533d4c4-53f1-4d68-b7b8-a575413b7edd" />
<img width="772" height="599" alt="image" src="https://github.com/user-attachments/assets/690d7e0f-efb6-40d7-9bdd-ba4fa9fe1d5b" />

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Could this affect a user’s behavior? We probably need to update docs! -->
yes, to add optional configurations for the chunks
<!-- If docs will be needed or you’re not sure, uncomment the next line: -->
 cc @withastro/maintainers-docs for feedback! 

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- https://github.com/withastro/docs -->
